### PR TITLE
[Frontend] feat: add ResultPage component to display analysis result

### DIFF
--- a/frontend/src/components/ResultPage.tsx
+++ b/frontend/src/components/ResultPage.tsx
@@ -1,0 +1,24 @@
+interface ResultProps {
+  result?: string
+}
+
+export const ResultPage = ({ result }: ResultProps) => {
+  const finalResult = result ? result : 'No result available.'
+
+  return (
+    <div className="container mx-auto py-12 px-4">
+      <h1 className="text-4xl font-bold mb-6 text-center">Analysis Result</h1>
+      <div className="w-full max-w-3xl mx-auto border rounded-lg border-gray-100 shadow-md">
+        <div className="p-6 border-b border-gray-100 bg-white">
+          <h2 className="text-xl font-semibold">Your Analysis</h2>
+          <p className="text-gray-500 text-sm mt-1">Here's the detailed result of your analysis</p>
+        </div>
+        <div className="p-6 bg-white">
+          <div className="p-4 bg-gray-100 rounded-md">
+            <p>{finalResult}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ResultPage.tsx
+++ b/frontend/src/components/ResultPage.tsx
@@ -15,7 +15,7 @@ export const ResultPage = ({ result }: ResultProps) => {
         </div>
         <div className="p-6 bg-white">
           <div className="p-4 bg-gray-100 rounded-md">
-            <p>{finalResult}</p>
+            <p className="whitespace-pre-wrap">{finalResult}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
#4 Added ResultPage.tsx to display the analysis result. The result is passed via props. If no result is available, a fallback message is shown. The UI is clean, accessible, and user-friendly, following all criteria from the issue.