### PR TITLE
[Backend] fix: surveys database race condition

### DIFF
--- a/survey/src/main/java/com/formulai/survey/SurveyServiceApplication.java
+++ b/survey/src/main/java/com/formulai/survey/SurveyServiceApplication.java
@@ -11,9 +11,6 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 import jakarta.persistence.EntityManagerFactory;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -38,7 +35,7 @@ public class SurveyServiceApplication {
 	@Bean(name = DATABASE_STARTUP_VALIDATOR)
     public DatabaseStartupValidator databaseStartupValidator(DataSource dataSource) {
 		var dsv = new DatabaseStartupValidator();
-        dsv.setDataSource(dataSource);
+		dsv.setDataSource(dataSource);
 		dsv.setInterval(3);
 		dsv.setTimeout(60);
 

--- a/survey/src/main/java/com/formulai/survey/SurveyServiceApplication.java
+++ b/survey/src/main/java/com/formulai/survey/SurveyServiceApplication.java
@@ -1,16 +1,28 @@
 package com.formulai.survey;
 
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.support.DatabaseStartupValidator;
+
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
+import jakarta.persistence.EntityManagerFactory;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
+import java.util.stream.Stream;
+
+import javax.sql.DataSource;
 
 @SpringBootApplication
 public class SurveyServiceApplication {
+
+	public static final String DATABASE_STARTUP_VALIDATOR = "databaseStartupValidator";
 
 	public static void main(String[] args) {
 		SpringApplication.run(SurveyServiceApplication.class, args);
@@ -21,5 +33,25 @@ public class SurveyServiceApplication {
 		return new OpenAPI()
 			.info(new Info().title("Survey API").version("1.0"))
 			.servers(List.of(new Server().url("http://localhost/api/survey")));
+	}
+
+	@Bean(name = DATABASE_STARTUP_VALIDATOR)
+    public DatabaseStartupValidator databaseStartupValidator(DataSource dataSource) {
+		var dsv = new DatabaseStartupValidator();
+        dsv.setDataSource(dataSource);
+		dsv.setInterval(3);
+		dsv.setTimeout(60);
+
+        return dsv;
+    }
+
+	@Bean
+	public static BeanFactoryPostProcessor dependsOnPostProcessor() {
+		return bf -> {
+			String[] jpa = bf.getBeanNamesForType(EntityManagerFactory.class);
+			Stream.of(jpa)
+					.map(bf::getBeanDefinition)
+					.forEach(it -> it.setDependsOn(DATABASE_STARTUP_VALIDATOR));
+		};
 	}
 }


### PR DESCRIPTION
Pull requests fixes database race condition that occurs during Hiberate scheme sync and database seeding from data.sql

**NOTE**: database is currenty created by pgsql database initialization, because of that, if user manually deletes survey database and restarts database container, survey database won't be created!