### PR TITLE
77 survey add test coverage and ci check for survey service

### DIFF
--- a/survey/.github/workflows/test.yml
+++ b/survey/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Backend Tests
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: ''
+      - run: mvn clean verify

--- a/survey/.github/workflows/test.yml
+++ b/survey/.github/workflows/test.yml
@@ -11,5 +11,31 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: '21'
-          distribution: ''
-      - run: mvn clean verify
+          distribution: 'jdk'
+      - name: Run tests and verify coverage
+        run: mvn clean verify
+      - name: Check code coverage threshold
+        run: |
+          if [ ! -f target/site/jacoco/jacoco.xml ]; then
+            echo "Nie znaleziono raportu pokrycia JaCoCo"
+            exit 1
+          fi
+
+          # Wyświetlenie aktualnego pokrycia
+          COVERAGE_WITH_PERCENT=$(grep -Po 'Total.*?([0-9\.]+)%' target/site/jacoco/index.html | grep -Po '[0-9\.]+%')
+          COVERAGE=$(echo $COVERAGE_WITH_PERCENT | sed 's/%//')
+          echo "Aktualne pokrycie kodu: $COVERAGE_WITH_PERCENT"
+
+          # Sprawdzenie czy pokrycie spełnia wymagany próg 80%
+          if (( $(echo "$COVERAGE < 80" | bc -l) )); then
+            echo "Błąd: Pokrycie kodu jest poniżej wymaganego progu 80%"
+            exit 1
+          else
+            echo "Sukces: Pokrycie kodu spełnia wymagany próg 80%"
+          fi
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: target/site/jacoco/

--- a/survey/pom.xml
+++ b/survey/pom.xml
@@ -57,8 +57,6 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.32</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -73,37 +71,51 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-			  <groupId>org.jacoco</groupId>
-			  <artifactId>jacoco-maven-plugin</artifactId>
-			  <version>0.8.8</version>
-			  <executions>
-				<execution>
-				  <goals>
-					<goal>prepare-agent</goal>
-				  </goals>
-				</execution>
-				<execution>
-				  <id>report</id>
-				  <phase>verify</phase>
-				  <goals>
-					<goal>report</goal>
-				  </goals>
-				</execution>
-			  </executions>
-			  <configuration>
-				<rules>
-				  <rule>
-					<element>BUNDLE</element>
-					<limits>
-					  <limit>
-						<counter>LINE</counter>
-						<value>COVEREDRATIO</value>
-						<minimum>0.80</minimum>
-					  </limit>
-					</limits>
-				  </rule>
-				</rules>
-			  </configuration>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.32</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.11</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>report</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<rules>
+						<rule>
+							<element>BUNDLE</element>
+							<limits>
+								<limit>
+									<counter>LINE</counter>
+									<value>COVEREDRATIO</value>
+									<minimum>0.80</minimum>
+								</limit>
+							</limits>
+						</rule>
+					</rules>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/survey/pom.xml
+++ b/survey/pom.xml
@@ -57,6 +57,8 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>1.18.32</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -69,6 +71,39 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+			  <groupId>org.jacoco</groupId>
+			  <artifactId>jacoco-maven-plugin</artifactId>
+			  <version>0.8.8</version>
+			  <executions>
+				<execution>
+				  <goals>
+					<goal>prepare-agent</goal>
+				  </goals>
+				</execution>
+				<execution>
+				  <id>report</id>
+				  <phase>verify</phase>
+				  <goals>
+					<goal>report</goal>
+				  </goals>
+				</execution>
+			  </executions>
+			  <configuration>
+				<rules>
+				  <rule>
+					<element>BUNDLE</element>
+					<limits>
+					  <limit>
+						<counter>LINE</counter>
+						<value>COVEREDRATIO</value>
+						<minimum>0.80</minimum>
+					  </limit>
+					</limits>
+				  </rule>
+				</rules>
+			  </configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/survey/src/main/java/com/formulai/survey/model/Task.java
+++ b/survey/src/main/java/com/formulai/survey/model/Task.java
@@ -9,14 +9,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Setter
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "task")
@@ -30,8 +28,8 @@ public class Task {
 
     @Column(name = "created_at")
     private Date createdAt;
-    
+
     private String status;
-    
+
     private String result;
 }

--- a/survey/src/test/java/com/formulai/survey/integrationTests/SurveyControllerTest.java
+++ b/survey/src/test/java/com/formulai/survey/integrationTests/SurveyControllerTest.java
@@ -1,0 +1,170 @@
+package com.formulai.survey.integrationTests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.formulai.survey.dto.request.SurveyRequest;
+import com.formulai.survey.dto.response.SurveyAnswerResponse;
+import com.formulai.survey.dto.response.SurveyResponse;
+import com.formulai.survey.model.Survey;
+import com.formulai.survey.repository.SurveyRepository;
+import com.formulai.survey.service.SurveyService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class SurveyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private SurveyRepository surveyRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void getSurvey_shouldReturnSurveyById() throws Exception {
+        // given
+        Survey firstSurvey = surveyRepository.findAll().stream()
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("No surveys found"));
+        UUID surveyId = firstSurvey.getId();
+
+        // when
+        MvcResult result = mockMvc.perform(get("/v1/surveys/" + surveyId))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // then
+        SurveyResponse response = objectMapper.readValue(
+                result.getResponse().getContentAsString(), SurveyResponse.class);
+
+        assertNotNull(response);
+        assertEquals(firstSurvey.getId(), response.id());
+        assertEquals(firstSurvey.getName(), response.name());
+        assertEquals(firstSurvey.getSchemaJson(), response.schemaJson());
+    }
+
+    @Test
+    void getAllSurveys_shouldReturnAllSurveys() throws Exception {
+        // given
+        List<Survey> surveys = surveyRepository.findAll();
+
+        // when
+        MvcResult result = mockMvc.perform(get("/v1/surveys"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // then
+        List<SurveyResponse> responses = objectMapper.readValue(
+                result.getResponse().getContentAsString(),
+                objectMapper.getTypeFactory().constructCollectionType(List.class, SurveyResponse.class));
+
+        assertNotNull(responses);
+        assertEquals(surveys.size(), responses.size());
+    }
+
+    @Test
+    void getAllSurveyResponses_shouldReturnAllResponsesForSurvey() throws Exception {
+        // given
+        Survey firstSurvey = surveyRepository.findByName("example")
+                .orElseThrow(() -> new RuntimeException("No surveys found"));
+        UUID surveyId = firstSurvey.getId();
+
+        // when
+        MvcResult result = mockMvc.perform(get("/v1/surveys/" + surveyId + "/answers"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // then
+        List<SurveyAnswerResponse> responses = objectMapper.readValue(
+                result.getResponse().getContentAsString(),
+                objectMapper.getTypeFactory().constructCollectionType(List.class, SurveyAnswerResponse.class));
+
+        assertNotNull(responses);
+        assertFalse(responses.isEmpty());
+        assertEquals(surveyId, responses.getFirst().surveyId());
+    }
+
+
+    @Test
+    void createSurvey_shouldReturn400WithInvalidRequest() throws Exception {
+        // given
+        SurveyRequest invalidRequest = new SurveyRequest(null, "{}");
+        String requestJson = objectMapper.writeValueAsString(invalidRequest);
+
+        // when and then
+        mockMvc.perform(post("/v1/surveys")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createSurvey_shouldReturn400WithEmptyName() throws Exception {
+        // given
+        SurveyRequest invalidRequest = new SurveyRequest("", "{}");
+        String requestJson = objectMapper.writeValueAsString(invalidRequest);
+
+        // when and then
+        mockMvc.perform(post("/v1/surveys")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createSurvey_shouldReturn400WithNullSchemaJson() throws Exception {
+        // given
+        SurveyRequest invalidRequest = new SurveyRequest("Nazwa ankiety", null);
+        String requestJson = objectMapper.writeValueAsString(invalidRequest);
+
+        // when & then
+        mockMvc.perform(post("/v1/surveys")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getSurvey_shouldHandleInvalidUUID() throws Exception {
+        // given
+        String invalidUUID = "not-a-uuid";
+
+        // when and then
+        mockMvc.perform(get("/v1/surveys/" + invalidUUID))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void submitSurvey_shouldReturn400WithMissingBody() throws Exception {
+        // given
+        Survey firstSurvey = surveyRepository.findAll().stream()
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("No surveys found"));
+        UUID surveyId = firstSurvey.getId();
+
+        // when and then
+        mockMvc.perform(post("/v1/surveys/" + surveyId + "/submit")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+
+
+}

--- a/survey/src/test/java/com/formulai/survey/integrationTests/SurveyServiceTest.java
+++ b/survey/src/test/java/com/formulai/survey/integrationTests/SurveyServiceTest.java
@@ -1,0 +1,203 @@
+package com.formulai.survey.integrationTests;
+
+import com.formulai.survey.dto.request.SurveyRequest;
+import com.formulai.survey.dto.request.SurveySubmitRequest;
+import com.formulai.survey.dto.response.SurveyAnswerResponse;
+import com.formulai.survey.dto.response.SurveyResponse;
+import com.formulai.survey.model.Survey;
+import com.formulai.survey.model.SurveyAnswers;
+import com.formulai.survey.model.Task;
+import com.formulai.survey.repository.SurveyRepository;
+import com.formulai.survey.repository.SurveyAnswerRepository;
+
+import com.formulai.survey.service.SurveyService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class SurveyServiceTest {
+    @Mock
+    private SurveyRepository surveyRepository;
+    @Mock
+    private SurveyAnswerRepository surveyAnswerRepository;
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private SurveyService surveyService;
+
+    private UUID surveyId;
+    private Survey survey;
+    private SurveyAnswers surveyAnswers;
+    private Task task;
+
+    @BeforeEach
+    void setUp() {
+        surveyId = UUID.randomUUID();
+
+        survey = Survey.builder()
+                .id(surveyId)
+                .name("Test Survey")
+                .schemaJson("{\"questions\": []}")
+                .answers(new ArrayList<>())
+                .tasks(new ArrayList<>())
+                .build();
+
+        task = Task.builder()
+                .id(UUID.randomUUID())
+                .survey(survey)
+                .createdAt(new Date())
+                .status("IN_PROGRESS")
+                .build();
+
+        List<Task> tasks = new ArrayList<>();
+        tasks.add(task);
+        survey.setTasks(tasks);
+
+        surveyAnswers = SurveyAnswers.builder()
+                .id(UUID.randomUUID())
+                .survey(survey)
+                .answersJson("{\"answers\": []}")
+                .build();
+
+        ReflectionTestUtils.setField(surveyService, "processingBaseUrl", "http://processing-service");
+        ReflectionTestUtils.setField(surveyService, "restTemplate", restTemplate);
+    }
+
+    @Test
+    void getSurveyById_shouldReturnSurveyResponse_whenSurveyExists() {
+        // given
+        when(surveyRepository.findById(surveyId)).thenReturn(Optional.of(survey));
+
+        // when
+        SurveyResponse response = surveyService.getSurveyById(surveyId);
+
+        //then
+        assertNotNull(response);
+        assertEquals(surveyId, response.id());
+        assertEquals("Test Survey", response.name());
+        verify(surveyRepository).findById(surveyId);
+    }
+
+    @Test
+    void getSurveyById_shouldThrowException_whenSurveyDoesNotExist() {
+        // given
+        when(surveyRepository.findById(surveyId)).thenReturn(Optional.empty());
+
+        // when
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> surveyService.getSurveyById(surveyId)
+        );
+
+        // then
+        assertTrue(exception.getMessage().contains("not found"));
+        verify(surveyRepository).findById(surveyId);
+    }
+
+    @Test
+    void getAllSurvey_shouldReturnAllSurveys() {
+        // given
+        when(surveyRepository.findAll()).thenReturn(List.of(survey));
+
+        // when
+        List<SurveyResponse> result = surveyService.getAllSurvey();
+
+        //then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(surveyId, result.getFirst().id());
+        verify(surveyRepository).findAll();
+    }
+
+    @Test
+    void createSurvey_shouldCreateAndReturnSurvey() {
+        // given
+        SurveyRequest request = new SurveyRequest("New Survey", "{\"questions\": []}");
+        Survey newSurvey = Survey.builder()
+                .id(UUID.randomUUID())
+                .name("New Survey")
+                .schemaJson("{\"questions\":[]}")
+                .tasks(List.of())
+                .build();
+
+        when(surveyRepository.save(any(Survey.class))).thenReturn(newSurvey);
+
+        // when
+        SurveyResponse result = surveyService.createSurvey(request);
+
+        // then
+        assertNotNull(result);
+        assertEquals("New Survey", result.name());
+        assertEquals("{\"questions\":[]}", result.schemaJson());
+        verify(surveyRepository).save(any(Survey.class));
+    }
+
+    @Test
+    void getResponses_shouldReturnAllResponsesForSurvey() {
+        // given
+        when(surveyAnswerRepository.findAllBySurveyId(surveyId)).thenReturn(List.of(surveyAnswers));
+
+        //when
+        List<SurveyAnswerResponse> result = surveyService.getResponses(surveyId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(surveyId, result.getFirst().surveyId());
+        assertEquals("{\"answers\": []}", result.getFirst().answersJson());
+        verify(surveyAnswerRepository).findAllBySurveyId(surveyId);
+    }
+
+    @Test
+    void submitSurveyRequest_shouldSaveAndReturnSurveyAnswer() {
+        // given
+        SurveySubmitRequest request = new SurveySubmitRequest("{\"answers\":[{\"questionId\":1,\"answer\":\"New Answer\"}]}");
+
+        when(surveyRepository.findById(surveyId)).thenReturn(Optional.of(survey));
+        when(surveyAnswerRepository.save(any(SurveyAnswers.class))).thenReturn(surveyAnswers);
+
+        // when
+        SurveyAnswerResponse result = surveyService.submitSurveyRequest(surveyId, request);
+
+        // then
+        assertNotNull(result);
+        assertEquals(surveyId, result.surveyId());
+        verify(surveyRepository).findById(surveyId);
+        verify(surveyAnswerRepository).save(any(SurveyAnswers.class));
+    }
+
+    @Test
+    void closeSurvey_shouldCallProcessingServiceAndReturnResult() {
+        // given
+        ResponseEntity<String> responseEntity = ResponseEntity.ok("Processing started");
+
+        when(restTemplate.postForEntity(contains("/surveys/" + surveyId + "/start"),
+                                        isNull(),
+                                        eq(String.class))
+                ).thenReturn(responseEntity);
+
+        // when
+        String result = surveyService.closeSurvey(surveyId);
+
+        // then
+        assertEquals("Processing started", result);
+        verify(restTemplate).postForEntity(contains("/surveys/" + surveyId + "/start"),
+                                           isNull(),
+                                           eq(String.class));
+    }
+
+
+}

--- a/survey/src/test/java/com/formulai/survey/unitTests/SurveyControllerTest.java
+++ b/survey/src/test/java/com/formulai/survey/unitTests/SurveyControllerTest.java
@@ -1,0 +1,160 @@
+package com.formulai.survey.unitTests;
+
+import com.formulai.survey.controllers.SurveyController;
+import com.formulai.survey.dto.request.SurveyRequest;
+import com.formulai.survey.dto.request.SurveySubmitRequest;
+import com.formulai.survey.dto.response.SurveyAnswerResponse;
+import com.formulai.survey.dto.response.SurveyResponse;
+import com.formulai.survey.service.SurveyService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SurveyControllerTest {
+    @Mock
+    private SurveyService surveyService;
+
+    @InjectMocks
+    private SurveyController surveyController;
+
+    private UUID surveyId;
+    private List<SurveyResponse> surveys;
+    private SurveyResponse expectedSurvey;
+    private List<SurveyAnswerResponse> answers;
+    private SurveyAnswerResponse expectedAnswer;
+
+    @BeforeEach
+    void setUp() {
+        surveyId = UUID.randomUUID();
+        surveys = List.of(
+                new SurveyResponse(surveyId, "Survey 1", "{}", "COMPLETED", null),
+                new SurveyResponse(UUID.randomUUID(), "Survey 2", "{}", "IN_PROGRESS", null)
+        );
+        expectedSurvey = surveys.getFirst();
+
+        answers = List.of(
+                new SurveyAnswerResponse(surveyId, "{}"),
+                new SurveyAnswerResponse(surveyId, "{}")
+        );
+        expectedAnswer = answers.getFirst();
+    }
+
+
+    @Test
+    void getSurvey_shouldReturnSurveyResponse() {
+        // given
+        when(surveyService.getSurveyById(surveyId)).thenReturn(expectedSurvey);
+
+        // when
+        ResponseEntity<SurveyResponse> result = surveyController.getSurvey(surveyId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(expectedSurvey, result.getBody());
+        verify(surveyService).getSurveyById(surveyId);
+    }
+
+    @Test
+    void getAllSurveys_shouldReturnAllSurveys() {
+        // given
+        when(surveyService.getAllSurvey()).thenReturn(surveys);
+
+        // when
+        ResponseEntity<List<SurveyResponse>> result = surveyController.getAllSurveys();
+
+        // then
+        assertNotNull(result);
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(surveys, result.getBody());
+        assertNotNull(result.getBody());
+        assertEquals(2, result.getBody().size());
+        verify(surveyService).getAllSurvey();
+    }
+
+    @Test
+    void createSurvey_shouldCreateAndReturnSurvey() {
+        // given
+        SurveyRequest request = new SurveyRequest("New Survey", "{/}");
+        SurveyResponse response = new SurveyResponse(
+                UUID.randomUUID(), "New Survey", "{}", null, null);
+
+        when(surveyService.createSurvey(request)).thenReturn(response);
+
+        // when
+        ResponseEntity<SurveyResponse> result = surveyController.createSurvey(request);
+
+        // then
+        assertNotNull(result);
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(response, result.getBody());
+        verify(surveyService).createSurvey(request);
+    }
+
+    @Test
+    void getAllSurveyResponses_shouldReturnAllResponsesForSurvey() {
+        // given
+        when(surveyService.getResponses(surveyId)).thenReturn(answers);
+
+        // when
+        ResponseEntity<List<SurveyAnswerResponse>> result = surveyController.getAllSurveyResponses(surveyId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(answers, result.getBody());
+        assertNotNull(result.getBody());
+        assertEquals(2, result.getBody().size());
+        verify(surveyService).getResponses(surveyId);
+    }
+
+    @Test
+    void submitSurvey_shouldSubmitAndReturnResponse() {
+        //given
+        SurveySubmitRequest request = new SurveySubmitRequest("{}");
+
+        when(surveyService.submitSurveyRequest(surveyId, request)).thenReturn(expectedAnswer);
+
+        //when
+        ResponseEntity<SurveyAnswerResponse> response = surveyController.submitSurvey(surveyId, request);
+
+        //then
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(expectedAnswer, response.getBody());
+        verify(surveyService).submitSurveyRequest(surveyId, request);
+    }
+
+    @Test
+    void closeSurvey_shouldCloseAndReturnResult() {
+        // given
+        String expectedResult = "Processing started";
+
+        when(surveyService.closeSurvey(surveyId)).thenReturn(expectedResult);
+
+        // when
+        ResponseEntity<String> result = surveyController.closeSurvey(surveyId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        assertEquals(expectedResult, result.getBody());
+        verify(surveyService).closeSurvey(surveyId);
+    }
+
+
+}

--- a/survey/src/test/java/com/formulai/survey/unitTests/SurveyServiceTest.java
+++ b/survey/src/test/java/com/formulai/survey/unitTests/SurveyServiceTest.java
@@ -1,0 +1,202 @@
+package com.formulai.survey.unitTests;
+
+import com.formulai.survey.dto.request.SurveyRequest;
+import com.formulai.survey.dto.request.SurveySubmitRequest;
+import com.formulai.survey.dto.response.SurveyAnswerResponse;
+import com.formulai.survey.dto.response.SurveyResponse;
+import com.formulai.survey.model.Survey;
+import com.formulai.survey.model.SurveyAnswers;
+import com.formulai.survey.model.Task;
+import com.formulai.survey.repository.SurveyRepository;
+import com.formulai.survey.repository.SurveyAnswerRepository;
+
+import com.formulai.survey.service.SurveyService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class SurveyServiceTest {
+    @Mock
+    private SurveyRepository surveyRepository;
+    @Mock
+    private SurveyAnswerRepository surveyAnswerRepository;
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private SurveyService surveyService;
+
+    private UUID surveyId;
+    private Survey survey;
+    private SurveyAnswers surveyAnswers;
+    private Task task;
+
+    @BeforeEach
+    void setUp() {
+        surveyId = UUID.randomUUID();
+
+        survey = Survey.builder()
+                .id(surveyId)
+                .name("Test Survey")
+                .schemaJson("{\"questions\": []}")
+                .answers(new ArrayList<>())
+                .tasks(new ArrayList<>())
+                .build();
+
+        task = Task.builder()
+                .id(UUID.randomUUID())
+                .survey(survey)
+                .createdAt(new Date())
+                .status("IN_PROGRESS")
+                .build();
+
+        List<Task> tasks = new ArrayList<>();
+        tasks.add(task);
+        survey.setTasks(tasks);
+
+        surveyAnswers = SurveyAnswers.builder()
+                .id(UUID.randomUUID())
+                .survey(survey)
+                .answersJson("{\"answers\": []}")
+                .build();
+
+        ReflectionTestUtils.setField(surveyService, "processingBaseUrl", "http://processing-service");
+        ReflectionTestUtils.setField(surveyService, "restTemplate", restTemplate);
+    }
+
+    @Test
+    void getSurveyById_shouldReturnSurveyResponse_whenSurveyExists() {
+        // given
+        when(surveyRepository.findById(surveyId)).thenReturn(Optional.of(survey));
+
+        // when
+        SurveyResponse response = surveyService.getSurveyById(surveyId);
+
+        //then
+        assertNotNull(response);
+        assertEquals(surveyId, response.id());
+        assertEquals("Test Survey", response.name());
+        verify(surveyRepository).findById(surveyId);
+    }
+
+    @Test
+    void getSurveyById_shouldThrowException_whenSurveyDoesNotExist() {
+        // given
+        when(surveyRepository.findById(surveyId)).thenReturn(Optional.empty());
+
+        // when
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> surveyService.getSurveyById(surveyId)
+        );
+
+        // then
+        assertTrue(exception.getMessage().contains("not found"));
+        verify(surveyRepository).findById(surveyId);
+    }
+
+    @Test
+    void getAllSurvey_shouldReturnAllSurveys() {
+        // given
+        when(surveyRepository.findAll()).thenReturn(List.of(survey));
+
+        // when
+        List<SurveyResponse> result = surveyService.getAllSurvey();
+
+        //then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(surveyId, result.getFirst().id());
+        verify(surveyRepository).findAll();
+    }
+
+    @Test
+    void createSurvey_shouldCreateAndReturnSurvey() {
+        // given
+        SurveyRequest request = new SurveyRequest("New Survey", "{\"questions\": []}");
+        Survey newSurvey = Survey.builder()
+                .id(UUID.randomUUID())
+                .name("New Survey")
+                .schemaJson("{\"questions\":[]}")
+                .tasks(List.of())
+                .build();
+
+        when(surveyRepository.save(any(Survey.class))).thenReturn(newSurvey);
+
+        // when
+        SurveyResponse result = surveyService.createSurvey(request);
+
+        // then
+        assertNotNull(result);
+        assertEquals("New Survey", result.name());
+        assertEquals("{\"questions\":[]}", result.schemaJson());
+        verify(surveyRepository).save(any(Survey.class));
+    }
+
+    @Test
+    void getResponses_shouldReturnAllResponsesForSurvey() {
+        // given
+        when(surveyAnswerRepository.findAllBySurveyId(surveyId)).thenReturn(List.of(surveyAnswers));
+
+        //when
+        List<SurveyAnswerResponse> result = surveyService.getResponses(surveyId);
+
+        // then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals(surveyId, result.getFirst().surveyId());
+        assertEquals("{\"answers\": []}", result.getFirst().answersJson());
+        verify(surveyAnswerRepository).findAllBySurveyId(surveyId);
+    }
+
+    @Test
+    void submitSurveyRequest_shouldSaveAndReturnSurveyAnswer() {
+        // given
+        SurveySubmitRequest request = new SurveySubmitRequest("{\"answers\":[{\"questionId\":1,\"answer\":\"New Answer\"}]}");
+
+        when(surveyRepository.findById(surveyId)).thenReturn(Optional.of(survey));
+        when(surveyAnswerRepository.save(any(SurveyAnswers.class))).thenReturn(surveyAnswers);
+
+        // when
+        SurveyAnswerResponse result = surveyService.submitSurveyRequest(surveyId, request);
+
+        // then
+        assertNotNull(result);
+        assertEquals(surveyId, result.surveyId());
+        verify(surveyRepository).findById(surveyId);
+        verify(surveyAnswerRepository).save(any(SurveyAnswers.class));
+    }
+
+    @Test
+    void closeSurvey_shouldCallProcessingServiceAndReturnResult() {
+        // given
+        ResponseEntity<String> responseEntity = ResponseEntity.ok("Processing started");
+
+        when(restTemplate.postForEntity(contains("/surveys/" + surveyId + "/start"),
+                                        isNull(),
+                                        eq(String.class))
+                ).thenReturn(responseEntity);
+
+        // when
+        String result = surveyService.closeSurvey(surveyId);
+
+        // then
+        assertEquals("Processing started", result);
+        verify(restTemplate).postForEntity(contains("/surveys/" + surveyId + "/start"),
+                                           isNull(),
+                                           eq(String.class));
+    }
+
+
+}


### PR DESCRIPTION
This pull request introduces several significant updates to the `survey` project, focusing on testing, code quality improvements, and build configuration. The changes include the addition of CI workflows, enhancements to the Maven build configuration, code refactoring, and the introduction of integration tests for the `SurveyService` and `SurveyController`.

### CI/CD Enhancements:
* Added a GitHub Actions workflow (`survey/.github/workflows/test.yml`) to automate backend tests, enforce a code coverage threshold of 80%, and upload JaCoCo coverage reports.

### Build Configuration:
* Updated `survey/pom.xml` to include the `maven-compiler-plugin` for annotation processing (e.g., Lombok) and the `jacoco-maven-plugin` for code coverage analysis, with a minimum coverage threshold of 80%.

### Code Refactoring:
* Refactored `SurveyService` to use a `final` `RestTemplate` and moved private helper methods (`fromSurvey`, `fromSurveyAnswers`, `toSurvey`) to the bottom of the class for improved readability. [[1]](diffhunk://#diff-b4866a03b9ed116454eb642a00eabbc7e44031e2f3533d5d3d0e4d6fc0b23880L37-R37) [[2]](diffhunk://#diff-b4866a03b9ed116454eb642a00eabbc7e44031e2f3533d5d3d0e4d6fc0b23880R79-R111)
* Simplified imports by removing unused ones in `SurveyService`.
* Added the `@Builder` annotation to the `Task` model for streamlined object creation using Lombok.

### Testing Improvements:
* Introduced integration tests for `SurveyController` (`survey/src/test/java/com/formulai/survey/integrationTests/SurveyControllerTest.java`) to validate endpoints, including scenarios for invalid input and edge cases.
* Added integration tests for `SurveyService` (`survey/src/test/java/com/formulai/survey/integrationTests/SurveyServiceTest.java`) to ensure correctness of service methods and handle various edge cases.

![obraz_2025-05-13_022640481](https://github.com/user-attachments/assets/a0eaaa1a-f2f6-4da3-9f00-d4c5b7d84d3a)

