### PR TITLE
Potential fix for code scanning alert no. 13: Use of externally-controlled format string

### DIFF
--- a/server/src/forms/email.service.ts
+++ b/server/src/forms/email.service.ts
@@ -59,7 +59,7 @@ export class EmailService {
         console.log(`Email would be sent to ${email}: ${info.messageId}`);
 
       } catch (error: any) {
-        console.error(`Failed to send email to ${email}:`, error);
+        console.error('Failed to send email to %s:', email, error);
         results.push({
           email: email.trim(),
           success: false,


### PR DESCRIPTION
Potential fix for [https://github.com/opendexcom/formul.ai/security/code-scanning/13](https://github.com/opendexcom/formul.ai/security/code-scanning/13)

To fix this issue, use an explicit format specifier when logging untrusted data, rather than interpolating it into the string. In other words, instead of using a template literal like `` `Failed to send email to ${email}:` ``, use a format string such as `"Failed to send email to %s:"` and pass the untrusted `email` value as an argument to `console.error`. This ensures the logger treats the value as a simple string, rather than parsing it (potentially as a format string) and ensures the output will not be garbled regardless of the content of `email`. Only the affected line (62) in `server/src/forms/email.service.ts` requires a change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
