### PR TITLE
feat: Gate SaaS UI with environment variable

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,1 +1,2 @@
 REACT_APP_API_BASE_URL=http://localhost:3001/api
+VITE_IS_SAAS=false

--- a/client/src/components/common/ShareFormModal.tsx
+++ b/client/src/components/common/ShareFormModal.tsx
@@ -4,6 +4,7 @@ import { FormData } from '../../services/formsService';
 import { Button } from '../ui';
 import Modal from '../ui/Modal';
 import { logger } from '../../utils/logger';
+import { isSaaS } from '../../utils/config';
 
 interface ShareFormModalProps {
   isOpen: boolean;
@@ -436,6 +437,8 @@ const ShareFormModal: React.FC<ShareFormModalProps> = ({
                     />
                   </button>
                 </div>
+                {isSaaS() && (
+                  
                 
                 <div className="border-t border-gray-200 pt-3">
                   <span className="text-sm font-medium text-gray-900">Response Limit</span>
@@ -446,7 +449,7 @@ const ShareFormModal: React.FC<ShareFormModalProps> = ({
                     className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500"
                   />
                 </div>
-                
+                )}
                 <div className="border-t border-gray-200 pt-3">
                   <span className="text-sm font-medium text-gray-900">Closing Date</span>
                   <p className="text-sm text-gray-600 mb-2">Automatically close form on specific date</p>

--- a/client/src/utils/config.ts
+++ b/client/src/utils/config.ts
@@ -1,0 +1,1 @@
+export const isSaaS = () => import.meta.env.VITE_IS_SAAS === 'true';


### PR DESCRIPTION
## Summary
Implements Issue #155 - Gates SaaS-specific UI elements with `VITE_IS_SAAS` environment variable.

## Changes
- ✅ Added `isSaaS()` helper function in `client/src/utils/config.ts`
- ✅ Added `VITE_IS_SAAS` to `.env` (defaults to `false` for OSS mode)
- ✅ Hidden "Response Limit" feature in `ShareFormModal.tsx` when in OSS mode

## How to test
1. Set `VITE_IS_SAAS=false` in `.env`
2. Restart dev server: `npm run dev`
3. Go to Dashboard → Share form → Settings tab
4. ✅ "Response Limit" section should be **hidden**

5. Set `VITE_IS_SAAS=true` in `.env`
6. Restart dev server
7. ✅ "Response Limit" section should be **visible**

Closes #155